### PR TITLE
Change example.js to server.lua.

### DIFF
--- a/doc/api/synopsis.markdown
+++ b/doc/api/synopsis.markdown
@@ -17,7 +17,7 @@ This simple web server written in Luvit responds with Hello World for every requ
     
     print('Server running at http://127.0.0.1:1337/')
 
-To run the server, put the code into a file called `example.js` and execute
+To run the server, put the code into a file called `server.lua` and execute
 it with using luvit
 
     > luvit server.lua


### PR DESCRIPTION
Currently the guide on the synopsis page asks the user to create a file named `example.js`, but directly below it asks them to run `server.lua`.

See https://luvit.io/api/synopsis.html for more information.
