### PR TITLE
path: correct pathEquals to pathsEqual

### DIFF
--- a/doc/api/path.markdown
+++ b/doc/api/path.markdown
@@ -2,7 +2,7 @@
 
 This module contains utilities for handling and transforming file paths. 
 Almost all these methods perform only string transformations. The file system is not consulted to check whether paths are valid.
-Supports both windows and posix.  
+Supports both windows and posix.
 
 Use `require('path')` to use this module. The following methods are provided:
 
@@ -12,11 +12,11 @@ Gets the filesystems root path.
 
 ## path.getSep()
 
-Gets the filesystems default path seperator
+Gets the filesystems default path seperator.
 
-## path.pathEquals(a, b)
+## path.pathsEqual(a, b)
 
-Checks if path a is equal to b
+Checks if path a is equal to b.
 
 ## path.normalize(filepath)
 
@@ -26,12 +26,12 @@ When multiple slashes are found, they're replaced by a single one; when the path
 
 ## path.join(...)
 
-Joins a splat of different strings together with the default seperator to form a valid path
+Joins a splat of different strings together with the default seperator to form a valid path.
 
 ## path.resolve([from ...], to)
 
-Works backwards, joining the arguments until it resolves to an absolute path. 
-If an absolute path is not resolved, then the current working directory is prepended
+Works backwards, joining the arguments until it resolves to an absolute path.
+If an absolute path is not resolved, then the current working directory is prepended.
 
 E.g.
 
@@ -41,8 +41,8 @@ E.g.
 ```
 ## path.relative(from, to)
 
-Returns the relative path from 'from' to 'to' 
-If no relative path can be solved, then 'to' is returned
+Returns the relative path from 'from' to 'to'.
+If no relative path can be solved, then 'to' is returned.
 
 ## path.dirname(filepath)
 
@@ -54,20 +54,20 @@ Return the last portion of a path. Similar to the Unix basename command.
 
 ## path.extname(filepath)
 
-Return the extension of the path, from the last '.' to end of string in the last portion of the path. If there is no '.' in the last portion of the path or the first character of it is '.', then it returns an empty string. Examples:
+Return the extension of the path, from the last '.' to end of string in the last portion of the path. If there is no '.' in the last portion of the path or the first character of it is '.', then it returns an empty string.
 
 ## path.isAbsolute(filepath)
 
-Checks if filepath is absolute
+Checks if filepath is absolute.
 
 ## path.isUNC(filepath)
 
-Checks if the path follows Microsofts universal naming convention
+Checks if the path follows Microsofts universal naming convention.
 
 ## path.isDriveRelative(filepath)
 
-Drive-relative paths are unique to Windows and use the format &lt;letter>:filepath
+Drive-relative paths are unique to Windows and use the format <letter>:filepath.
 
 ## path.normalizeSeparators(filepath)
 
-Returns file path with posix seperators
+Returns file path with posix seperators.


### PR DESCRIPTION
The path docs is referencing a method `path.pathEquals` which does not exists. Rather the name is `path.pathsEqual` (notice the s).

I did as well add a dot at the end of each sentence for consistency.